### PR TITLE
Add GET /users/me endpoint for logged-in user details

### DIFF
--- a/Business/src/main/java/cs/ubb/hrelperbe/Implementations/UserServiceImplementation.java
+++ b/Business/src/main/java/cs/ubb/hrelperbe/Implementations/UserServiceImplementation.java
@@ -4,6 +4,7 @@ import cs.ubb.hrelperbe.BaseModels.User;
 import cs.ubb.hrelperbe.Constants.UserType;
 import cs.ubb.hrelperbe.DTOs.AccountRegistrationData;
 import cs.ubb.hrelperbe.DTOs.LoginCredentials;
+import cs.ubb.hrelperbe.DTOs.UserDetailsData;
 import cs.ubb.hrelperbe.Interfaces.UserRepositoryInterface;
 import cs.ubb.hrelperbe.Interfaces.UserServiceInterface;
 import cs.ubb.hrelperbe.Mappers.UserMapper;
@@ -11,6 +12,8 @@ import cs.ubb.hrelperbe.authentication.TokenProvider;
 import cs.ubb.hrelperbe.validation.UserValidator;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Locale;
 
 @Service
 public class UserServiceImplementation implements UserServiceInterface {
@@ -53,5 +56,15 @@ public class UserServiceImplementation implements UserServiceInterface {
         String encodedPassword = passwordEncoder.encode(user.getPassword());
         user.setPassword(encodedPassword);
         userRepository.save(user);
+    }
+
+    @Override
+    public UserDetailsData getUserDetails(Integer userId) {
+        User user = userRepository.getUserById(userId);
+        return new UserDetailsData(
+                user.getName(),
+                user.getEmail(),
+                user.getType().name().toLowerCase(Locale.ROOT)
+        );
     }
 }

--- a/Business/src/main/java/cs/ubb/hrelperbe/Interfaces/UserServiceInterface.java
+++ b/Business/src/main/java/cs/ubb/hrelperbe/Interfaces/UserServiceInterface.java
@@ -2,9 +2,12 @@ package cs.ubb.hrelperbe.Interfaces;
 
 import cs.ubb.hrelperbe.DTOs.AccountRegistrationData;
 import cs.ubb.hrelperbe.DTOs.LoginCredentials;
+import cs.ubb.hrelperbe.DTOs.UserDetailsData;
 
 public interface UserServiceInterface {
     public String login(LoginCredentials loginCredentials);
 
     public void register(AccountRegistrationData accountRegistrationData);
+
+    public UserDetailsData getUserDetails(Integer userId);
 }

--- a/Model/src/main/java/cs/ubb/hrelperbe/DTOs/UserDetailsData.java
+++ b/Model/src/main/java/cs/ubb/hrelperbe/DTOs/UserDetailsData.java
@@ -1,0 +1,14 @@
+package cs.ubb.hrelperbe.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserDetailsData {
+    private String name;
+    private String email;
+    private String type;
+}

--- a/Persistence/src/main/java/cs/ubb/hrelperbe/Implementations/UserRepositoryImplementation.java
+++ b/Persistence/src/main/java/cs/ubb/hrelperbe/Implementations/UserRepositoryImplementation.java
@@ -44,6 +44,30 @@ public class UserRepositoryImplementation implements UserRepositoryInterface {
         }
     }
 
+    @Override
+    public User getUserById(Integer userId) {
+        try (
+                Connection connection = databaseConnection.getConnection();
+                PreparedStatement preparedStatement = connection.prepareStatement("select * from \"Users\" where \"userId\" = ?");
+        ) {
+            preparedStatement.setInt(1, userId);
+            ResultSet resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                String name = resultSet.getString("name");
+                String surname = resultSet.getString("surname");
+                String email = resultSet.getString("email");
+                String password = resultSet.getString("password");
+                String type = resultSet.getString("type");
+                UserType userType = UserType.valueOf(type);
+                return new User(userId, name, surname, email, password, userType);
+            } else {
+                throw new RuntimeException("User doesn't exist.");
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private boolean emailExists(String email) {
         Connection connection = null;
         try {

--- a/Persistence/src/main/java/cs/ubb/hrelperbe/Interfaces/UserRepositoryInterface.java
+++ b/Persistence/src/main/java/cs/ubb/hrelperbe/Interfaces/UserRepositoryInterface.java
@@ -5,5 +5,7 @@ import cs.ubb.hrelperbe.BaseModels.User;
 public interface UserRepositoryInterface {
     public User getUserByEmail(String email);
 
+    public User getUserById(Integer userId);
+
     public void save(User user);
 }

--- a/RestController/src/main/java/cs/ubb/hrelperbe/controller/UserController.java
+++ b/RestController/src/main/java/cs/ubb/hrelperbe/controller/UserController.java
@@ -2,8 +2,10 @@ package cs.ubb.hrelperbe.controller;
 
 import cs.ubb.hrelperbe.DTOs.AccountRegistrationData;
 import cs.ubb.hrelperbe.DTOs.LoginCredentials;
+import cs.ubb.hrelperbe.DTOs.UserDetailsData;
 import cs.ubb.hrelperbe.Implementations.UserServiceImplementation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,5 +29,11 @@ public class UserController {
     @PostMapping(path = "/register")
     public void register(@RequestBody AccountRegistrationData accountRegistrationData){
         userService.register(accountRegistrationData);
+    }
+
+    @GetMapping(path = "/me")
+    public UserDetailsData getLoggedInUser(Authentication authentication) {
+        Integer userId = Integer.parseInt(authentication.getName());
+        return userService.getUserDetails(userId);
     }
 }


### PR DESCRIPTION
Implemented a new endpoint: GET /users/me. It returns the authenticated user's profile details: name, email, and type. The endpoint uses the user ID from JWT authentication and fetches data from the Users table through service/repository layers.