### PR TITLE
Delete job by a specific id

### DIFF
--- a/Business/src/main/java/cs/ubb/hrelperbe/Implementations/JobServiceImplementation.java
+++ b/Business/src/main/java/cs/ubb/hrelperbe/Implementations/JobServiceImplementation.java
@@ -94,6 +94,11 @@ public class JobServiceImplementation implements JobServiceInterface {
         jobRepository.update(job);
     }
 
+        @Override
+        public void deleteJob(Integer jobId) {
+                jobRepository.deleteById(jobId);
+        }
+
     @Override
     public JobDetailsResponse getJobDetails(Integer jobId) {
         Job job = jobRepository.getJobDetailsById(jobId);

--- a/Business/src/main/java/cs/ubb/hrelperbe/Interfaces/JobServiceInterface.java
+++ b/Business/src/main/java/cs/ubb/hrelperbe/Interfaces/JobServiceInterface.java
@@ -8,5 +8,7 @@ public interface JobServiceInterface {
 
     public void updateJobPost(JobPostData jobPostData, Integer jobId);
 
+    public void deleteJob(Integer jobId);
+
     JobDetailsResponse getJobDetails(Integer jobId);
 }

--- a/Persistence/src/main/java/cs/ubb/hrelperbe/Implementations/JobRepositoryImplementation.java
+++ b/Persistence/src/main/java/cs/ubb/hrelperbe/Implementations/JobRepositoryImplementation.java
@@ -181,6 +181,39 @@ public class JobRepositoryImplementation implements JobRepositoryInterface {
         }
     }
 
+    @Override
+    public void deleteById(Integer jobId) {
+        try (Connection connection = databaseConnection.getConnection()) {
+
+            connection.setAutoCommit(false);
+
+            try {
+                deleteJobMustHaveSkills(connection, jobId);
+                deleteJobInterviewGuideQuestions(connection, jobId);
+                deleteJobTechnicalStack(connection, jobId);
+
+                try (PreparedStatement statement = connection.prepareStatement(
+                        "DELETE FROM \"Jobs\" WHERE \"jobId\" = ?"
+                )) {
+                    statement.setInt(1, jobId);
+                    int rows = statement.executeUpdate();
+                    if (rows == 0) {
+                        throw new RuntimeException("Job not found!");
+                    }
+                }
+
+                connection.commit();
+
+            } catch (Exception e) {
+                connection.rollback();
+                throw new RuntimeException(e);
+            }
+
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     private List<MustHaveSkill> getSkillsOfAJob(Connection connection, Integer jobId) {
         List<MustHaveSkill> skills = new ArrayList<>();
         try (PreparedStatement stmt = connection.prepareStatement("SELECT * FROM \"MustHaveSkills\" WHERE \"jobId\" = ?")) {

--- a/Persistence/src/main/java/cs/ubb/hrelperbe/Interfaces/JobRepositoryInterface.java
+++ b/Persistence/src/main/java/cs/ubb/hrelperbe/Interfaces/JobRepositoryInterface.java
@@ -7,5 +7,7 @@ public interface JobRepositoryInterface {
 
     public void update(Job job);
 
+    public void deleteById(Integer jobId);
+
     Job getJobDetailsById(Integer jobId);
 }

--- a/RestController/src/main/java/cs/ubb/hrelperbe/controller/JobController.java
+++ b/RestController/src/main/java/cs/ubb/hrelperbe/controller/JobController.java
@@ -29,17 +29,22 @@ public class JobController {
     }
 
     @PutMapping(path = "/{id}")
-    public void editJobPost(@RequestBody JobPostData jobPostData, @PathVariable Integer id){
+    public void editJobPost(@RequestBody JobPostData jobPostData, @PathVariable("id") Integer id){
         jobService.updateJobPost(jobPostData, id);
     }
 
+    @DeleteMapping(path = "/{id}")
+    public void deleteJob(@PathVariable("id") Integer id){
+        jobService.deleteJob(id);
+    }
+
     @GetMapping(path = "/{id}/quiz")
-    public List<QuizQuestionDTO> getQuizForJob(@PathVariable Integer id){
+    public List<QuizQuestionDTO> getQuizForJob(@PathVariable("id") Integer id){
         return quizService.getQuizForJob(id);
     }
 
     @GetMapping(path = "/{id}")
-    public JobDetailsResponse getJobDetailsById(@PathVariable Integer id) {
+    public JobDetailsResponse getJobDetailsById(@PathVariable("id") Integer id) {
         return jobService.getJobDetails(id);
     }
 }


### PR DESCRIPTION
Implemented DELETE /jobs/{id} with cascade cleanup of related data. Tested via Swagger by deleting job ID 4 and confirmed removal from Jobs and related tables.

